### PR TITLE
Add dark mode toggle feature with Prometheus metrics for Continuous Experimentation

### DIFF
--- a/app-service/app.py
+++ b/app-service/app.py
@@ -14,6 +14,8 @@ REQUEST_COUNT = Counter("webapp_requests_total", "Total number of requests", ["e
 SENTIMENT_COUNTER = Counter("sentiment_predictions_total", "Count of predicted sentiments", ["sentiment"])
 RESPONSE_TIME = Histogram("request_latency_seconds", "Histogram of response times", ["endpoint"])
 MODEL_VERSION_GAUGE = Gauge("model_version_info", "Model version info", ["version"])
+DARKMODE_TOGGLE = Counter("dark_mode_toggle_total", "Count of dark mode toggles", ["version"])
+
 
 # Environment URLs
 URL_MODEL_SERVICE = os.environ.get("URL_MODEL_SERVICE", "http://model-service:8000/predict") # Corrected from localhost
@@ -58,6 +60,14 @@ def model_version():
         print(traceback.format_exc()) 
         return jsonify({"error": "Could not fetch model version from model-service", "details": str(e)}), 502
 
+
+@api.route("/metrics/toggle", methods=["POST"])
+def track_dark_toggle():
+    try:
+        DARKMODE_TOGGLE.labels(version=os.getenv("APP_VERSION", "v1")).inc()
+        return '', 204
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 @api.route("/version", methods=["GET"])
 def version():

--- a/app-v2/Dockerfile
+++ b/app-v2/Dockerfile
@@ -1,0 +1,19 @@
+# FROM nginx:alpine
+# ARG APP_SERVICE_URL
+
+# COPY . /usr/share/nginx/html
+# RUN sed -i "s|__APP_SERVICE_URL__|${APP_SERVICE_URL}|g" /usr/share/nginx/html/config.js
+
+# EXPOSE 80
+
+FROM nginx:alpine
+
+# Copy frontend files into Nginx’s web root
+COPY . /usr/share/nginx/html
+
+# Copy entrypoint script into container
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Run the script on container start
+CMD ["/entrypoint.sh"]

--- a/app-v2/entrypoint.sh
+++ b/app-v2/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Replace the placeholder with the runtime environment variable
+sed -i "s|__APP_SERVICE_URL__|${APP_SERVICE_URL}|g" /usr/share/nginx/html/config.js
+
+# Start Nginx
+exec nginx -g "daemon off;"

--- a/app-v2/index.html
+++ b/app-v2/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ML Application</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>ML Sentiment Analysis</h1>
+            <div class="version-info">
+                <span id="app-version">App Version: Loading...</span>
+                <span id="model-version">Model Version: Loading...</span>
+            </div>
+        
+            <div class="dark-mode-toggle">
+                <label for="dark-toggle">🌙 Dark Mode:</label>
+                <input type="checkbox" id="dark-toggle">
+            </div>
+        </header>
+        
+
+        <main>
+            <div class="input-section">
+                <h2>Enter your restaurant review</h2>
+                <textarea id="review-input" placeholder="Type your restaurant review here..."></textarea>
+                <button id="submit-btn">Analyze Sentiment</button>
+            </div>
+
+            <div class="result-section" id="result-container">
+                <h2>Sentiment Analysis Result</h2>
+                <div class="result-display">
+                    <div id="sentiment-emoji">😐</div>
+                    <div id="sentiment-text">No analysis yet</div>
+                </div>
+                <div class="feedback-section">
+                    <p>Is this prediction correct?</p>
+                    <div class="feedback-buttons">
+                        <button id="correct-btn">Yes</button>
+                        <button id="incorrect-btn">No</button>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <footer>
+            <p>REMLA Project - Team X</p>
+        </footer>
+    </div>
+    
+    <script src="config.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/app-v2/script.js
+++ b/app-v2/script.js
@@ -1,0 +1,165 @@
+const API_BASE_URL = window.APP_SERVICE_URL || '/api';
+console.log("API_BASE_URL = ", API_BASE_URL);
+
+const ENDPOINTS = {
+    appVersion: '/version',
+    modelVersion: '/model_version',
+    analyze: '/analyze',
+    feedback: '/feedback'
+};
+
+// DOM Elements
+const elements = {
+    appVersion: document.getElementById('app-version'),
+    modelVersion: document.getElementById('model-version'),
+    reviewInput: document.getElementById('review-input'),
+    submitBtn: document.getElementById('submit-btn'),
+    resultContainer: document.getElementById('result-container'),
+    sentimentEmoji: document.getElementById('sentiment-emoji'),
+    sentimentText: document.getElementById('sentiment-text'),
+    correctBtn: document.getElementById('correct-btn'),
+    incorrectBtn: document.getElementById('incorrect-btn')
+};
+
+
+let currentAnalysis = null;
+
+async function fetchFromAPI(endpoint, method = 'GET', data = null) {
+    const options = {
+        method,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+
+    if (data) {
+        options.body = JSON.stringify(data);
+    }
+
+    try {
+        const response = await fetch(`${API_BASE_URL}${endpoint}`, options);
+
+        if (!response.ok) {
+            throw new Error(`API responded with status: ${response.status}\nURL: ${API_BASE_URL}${endpoint}`);
+        }
+
+        return await response.json();
+    } catch (error) {
+        console.error('API Error:', error);
+        return { error: error.message };
+    }
+}
+
+function updateUIWithSentiment(sentiment) {
+    // Store current analysis in state
+    currentAnalysis = sentiment;
+
+    // Update UI
+    if (sentiment.score > 0.6) {
+        elements.sentimentEmoji.textContent = '😃';
+        elements.sentimentText.textContent = 'Positive';
+        elements.sentimentText.style.color = '#2ecc71';
+    } else if (sentiment.score < 0.4) {
+        elements.sentimentEmoji.textContent = '😞';
+        elements.sentimentText.textContent = 'Negative';
+        elements.sentimentText.style.color = '#e74c3c';
+    } else {
+        elements.sentimentEmoji.textContent = '😐';
+        elements.sentimentText.textContent = 'Neutral';
+        elements.sentimentText.style.color = '#f39c12';
+    }
+}
+
+function displayError(message) {
+    elements.sentimentEmoji.textContent = '❌';
+    elements.sentimentText.textContent = message || 'Error processing request';
+    elements.sentimentText.style.color = '#e74c3c';
+}
+
+// Event handlers
+async function handleSubmit() {
+    const reviewText = elements.reviewInput.value.trim();
+
+    if (!reviewText) {
+        alert('Please enter a review first!');
+        return;
+    }
+
+    // Show loading state
+    elements.submitBtn.disabled = true;
+    elements.submitBtn.innerHTML = '<span class="loading"></span> Analyzing...';
+
+    try {
+        const result = await fetchFromAPI(ENDPOINTS.analyze, 'POST', {
+            text: reviewText
+        });
+
+        if (result.error) {
+            displayError(result.error);
+        } else {
+            updateUIWithSentiment(result);
+        }
+    } catch (error) {
+        displayError('Failed to analyze text');
+        console.error(error);
+    } finally {
+        elements.submitBtn.disabled = false;
+        elements.submitBtn.textContent = 'Analyze Sentiment';
+    }
+}
+
+// send feedback to app service
+function handleFeedback(isCorrect) {
+    if (!currentAnalysis) return;
+
+    fetchFromAPI('/feedback', 'POST', {
+        analysisId: currentAnalysis.id,
+        text: elements.reviewInput.value,
+        predictedSentiment: currentAnalysis.sentiment,
+        isCorrect: isCorrect
+    }).then(response => {
+        alert(isCorrect ? 'Thank you for confirming!' : 'Thank you for your feedback!');
+    }).catch(error => {
+        console.error('Error sending feedback:', error);
+    });
+}
+
+// Initialize application
+async function initApp() {
+    try {
+        // app version
+        const appVersionData = await fetchFromAPI(ENDPOINTS.appVersion);
+        if (!appVersionData.error) {
+            elements.appVersion.textContent = `App Version: ${appVersionData.version}`;
+        }
+
+        // model version
+        const modelVersionData = await fetchFromAPI(ENDPOINTS.modelVersion);
+        console.log(modelVersionData);
+        if (!modelVersionData.error) {
+            elements.modelVersion.textContent = `Model Version: ${modelVersionData.version}`;
+        }
+    } catch (error) {
+        console.error('Failed to initialize app:', error);
+    }
+}
+
+
+elements.submitBtn.addEventListener('click', handleSubmit);
+elements.correctBtn.addEventListener('click', () => handleFeedback(true));
+elements.incorrectBtn.addEventListener('click', () => handleFeedback(false));
+elements.reviewInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && e.ctrlKey) {
+        handleSubmit();
+    }
+});
+
+document.addEventListener('DOMContentLoaded', initApp);
+document.addEventListener('DOMContentLoaded', () => {
+    const darkToggle = document.getElementById('dark-toggle');
+    if (darkToggle) {
+        darkToggle.addEventListener('change', () => {
+            document.body.classList.toggle('dark-mode', darkToggle.target.checked);
+        });
+    }
+});

--- a/app-v2/script.js
+++ b/app-v2/script.js
@@ -158,8 +158,15 @@ document.addEventListener('DOMContentLoaded', initApp);
 document.addEventListener('DOMContentLoaded', () => {
     const darkToggle = document.getElementById('dark-toggle');
     if (darkToggle) {
-        darkToggle.addEventListener('change', () => {
-            document.body.classList.toggle('dark-mode', darkToggle.target.checked);
-        });
+      darkToggle.addEventListener('change', () => {
+        document.body.classList.toggle('dark-mode', darkToggle.checked);
+        fetch('/api/metrics/toggle', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ toggled: darkToggle.checked })
+          });
+          
+      });
     }
-});
+  });
+  

--- a/app-v2/styles.css
+++ b/app-v2/styles.css
@@ -1,0 +1,206 @@
+/* Base styles */
+:root {
+    --primary-color: #3498db;
+    --secondary-color: #2ecc71;
+    --danger-color: #e74c3c;
+    --text-color: #333;
+    --bg-color: #f5f5f5;
+    --container-bg: #ffffff;
+    --border-radius: 8px;
+    --box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header styles */
+header {
+    background-color: var(--container-bg);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    margin-bottom: 20px;
+}
+
+header h1 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 10px;
+}
+
+.version-info {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    color: #666;
+}
+
+/* Main content styles */
+main {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+}
+
+@media (min-width: 768px) {
+    main {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.input-section, .result-section {
+    background-color: var(--container-bg);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+h2 {
+    margin-bottom: 15px;
+    color: var(--primary-color);
+}
+
+/* Input area styles */
+#review-input {
+    width: 100%;
+    height: 150px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: var(--border-radius);
+    resize: none;
+    margin-bottom: 15px;
+    font-size: 1rem;
+}
+
+#submit-btn {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s;
+}
+
+#submit-btn:hover {
+    background-color: #2980b9;
+}
+
+.result-display {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+#sentiment-emoji {
+    font-size: 4rem;
+    margin-bottom: 10px;
+}
+
+#sentiment-text {
+    font-size: 1.2rem;
+    font-weight: bold;
+}
+
+.feedback-section {
+    text-align: center;
+}
+
+.feedback-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.feedback-buttons button {
+    padding: 8px 20px;
+    border: none;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+#correct-btn {
+    background-color: var(--secondary-color);
+    color: white;
+}
+
+#correct-btn:hover {
+    background-color: #27ae60;
+}
+
+#incorrect-btn {
+    background-color: var(--danger-color);
+    color: white;
+}
+
+#incorrect-btn:hover {
+    background-color: #c0392b;
+}
+
+/* Footer styles */
+footer {
+    text-align: center;
+    margin-top: 20px;
+    padding: 10px;
+    font-size: 0.9rem;
+    color: #666;
+}
+
+/* Loading spinner for API calls */
+.loading {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 3px solid rgba(0, 0, 0, 0.1);
+    border-radius: 50%;
+    border-top-color: var(--primary-color);
+    animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+
+.hidden {
+    display: none;
+}
+
+body.dark-mode {
+    background-color: #1e1e1e;
+    color: #f5f5f5;
+}
+
+body.dark-mode .container,
+body.dark-mode .input-section,
+body.dark-mode .result-section,
+body.dark-mode header {
+    background-color: #2e2e2e;
+    box-shadow: none;
+}
+
+body.dark-mode #review-input {
+    background-color: #444;
+    color: #fff;
+    border-color: #555;
+}

--- a/app-v2/styles.css
+++ b/app-v2/styles.css
@@ -189,18 +189,13 @@ footer {
 body.dark-mode {
     background-color: #1e1e1e;
     color: #f5f5f5;
-}
-
-body.dark-mode .container,
-body.dark-mode .input-section,
-body.dark-mode .result-section,
-body.dark-mode header {
+  }
+  
+  body.dark-mode .container,
+  body.dark-mode .input-section,
+  body.dark-mode .result-section,
+  body.dark-mode header {
     background-color: #2e2e2e;
     box-shadow: none;
-}
-
-body.dark-mode #review-input {
-    background-color: #444;
-    color: #fff;
-    border-color: #555;
-}
+  }
+  


### PR DESCRIPTION
Added dark mode toggle UI component in the frontend (v2 only).

Introduced JavaScript logic to:

Toggle the dark-mode class on the <body>.

Send POST requests to /api/metrics/toggle to log user interaction.

Exposed a new endpoint /api/metrics/toggle in the Flask backend to increment the dark_mode_toggle_total Prometheus counter.